### PR TITLE
Address Multithreading Problems - Stream Data First

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(client
     client.cpp
     client_utils.cpp
     client_utils.h
+    SharedQueue.h
     ../host/redis.cpp 
     ../crypto/encryption_engine.cpp
     ../gen-cpp/RPC.h

--- a/src/client/SharedQueue.h
+++ b/src/client/SharedQueue.h
@@ -1,0 +1,117 @@
+#include <iostream>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <queue>
+
+#include <chrono>
+#include <thrift/protocol/TBinaryProtocol.h>
+#include <thrift/transport/TSocket.h>
+#include <thrift/transport/TTransportUtils.h>
+
+#include "../constants/constants.h"
+#include "../gen-cpp/RPC.h"
+#include "client_utils.h"
+
+using namespace std::chrono;
+using namespace apache::thrift;
+using namespace apache::thrift::protocol;
+using namespace apache::thrift::transport;
+
+class SharedQueue {
+  private:
+    std::mutex mutex;
+    std::condition_variable cv;
+    std::queue<Operation> queue;
+    const int MaxQueueSize = 1000;
+
+    ClientConfig &config;
+  
+  public:
+    SharedQueue(ClientConfig &config): config(config) {};
+    
+    int enqueue() {
+        std::unique_lock<std::mutex> lock(mutex);
+
+        cv.wait(lock, [this] { return queue.size() < MaxQueueSize; });
+
+        if (!moreOperationsExist(config)) {
+            Operation op;
+            op.__set_key("EOF");
+            queue.push(op);
+
+            lock.unlock();
+            cv.notify_one();
+
+            return 1;
+        }
+
+        queue.push(getOperation(config));
+
+        lock.unlock();
+        cv.notify_one();
+        return 0;
+    }
+
+    Operation dequeue() {
+        std::unique_lock<std::mutex> lock(mutex);
+
+        cv.wait(lock, [this] { return !queue.empty(); });
+        
+        Operation data = queue.front();
+        queue.pop();
+
+        lock.unlock();
+        cv.notify_one();
+        return data;
+    }
+};
+
+class DataHandler {
+  private:
+    SharedQueue &sharedQueue;
+
+  public:
+    DataHandler(SharedQueue& sharedQueue): sharedQueue(sharedQueue) {}
+
+    void operator()() {
+        while (true) {
+            int enqueue_result = sharedQueue.enqueue();
+
+            if (enqueue_result == 1) return;
+        }
+    }
+};
+
+class ClientRunner {
+  private:
+    SharedQueue &sharedQueue;
+    std::vector<double> &latencies;
+
+  public:
+    ClientRunner(SharedQueue& sharedQueue, std::vector<double> &latencies): 
+        sharedQueue(sharedQueue), latencies(latencies) {}
+
+    void operator()() {
+        while (true) {
+            Operation data = sharedQueue.dequeue();
+
+            if (data.key == "EOF") return;
+
+            auto socket = std::make_shared<TSocket>(HOST_IP, HOST_PORT);
+            auto transport = std::make_shared<TBufferedTransport>(socket);
+            auto protocol = std::make_shared<TBinaryProtocol>(transport);
+            RPCClient client(protocol);
+
+            transport->open();
+
+            auto start = high_resolution_clock::now();
+            client.access(data);
+            auto end = high_resolution_clock::now();
+            latencies.push_back(
+                duration_cast<microseconds>(end - start).count());
+            
+            transport->close();
+        }
+    }
+};

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1,23 +1,12 @@
 #include <chrono>
-#include <fstream>
 #include <numeric>
-#include <sodium.h>
 #include <sstream>
-#include <thrift/protocol/TBinaryProtocol.h>
-#include <thrift/transport/TSocket.h>
-#include <thrift/transport/TTransportUtils.h>
 
-#include "../constants/constants.h"
-#include "../crypto/encryption_engine.h"
-#include "../gen-cpp/RPC.h"
 #include "../host/redis.h"
-#include "client_utils.h"
+#include "SharedQueue.h"
 #include "spdlog/spdlog.h"
 
 using namespace std::chrono;
-using namespace apache::thrift;
-using namespace apache::thrift::protocol;
-using namespace apache::thrift::transport;
 
 class ClientHandler {
   private:
@@ -44,35 +33,18 @@ class ClientHandler {
     }
 
     void runThreaded() {
-        std::vector<std::thread> threads;
+        SharedQueue sharedQueue(config);
+        std::vector<std::thread> data_handler_threads;
+        std::vector<std::thread> runner_threads;
+
         for (int i = 0; i < config.num_clients; i++) {
-            threads.push_back(std::thread(&ClientHandler::run, this));
+            data_handler_threads.push_back(std::thread(DataHandler(sharedQueue)));
+            runner_threads.push_back(std::thread(ClientRunner(sharedQueue, latencies)));
         }
 
-        // Wait for all threads to finish
-        for (std::thread &thread : threads) {
-            thread.join();
-        }
-    }
-
-    void run() {
-        auto socket = std::make_shared<TSocket>(HOST_IP, HOST_PORT);
-        auto transport = std::make_shared<TBufferedTransport>(socket);
-        auto protocol = std::make_shared<TBinaryProtocol>(transport);
-        RPCClient client(protocol);
-
-        transport->open();
-
-        while (moreOperationsExist(config)) {
-            Operation op = getOperation(config);
-            auto start = high_resolution_clock::now();
-            client.access(op);
-            auto end = high_resolution_clock::now();
-            latencies.push_back(
-                duration_cast<microseconds>(end - start).count());
-        }
-
-        transport->close();
+         // Join data handler and runner threads
+        for (auto& thread : data_handler_threads) thread.join();
+        for (auto& thread : runner_threads) thread.join();
     }
 
     float getAveLatency() {

--- a/src/client/client_utils.h
+++ b/src/client/client_utils.h
@@ -16,7 +16,9 @@ struct ClientConfig {
     int num_clients = 16;
     int num_operations = 1000;
     double p_get = 0.5;
+
     bool init_db = false;
+    bool use_seed = false;
 
     int max_key = 100000;
     int max_value = 100000;
@@ -33,8 +35,6 @@ Operation getSeedOperation(ClientConfig &config);
 Operation genRandInitValue(ClientConfig &config);
 
 Operation genRandOperation(ClientConfig &config);
-
-std::istream &readFile(std::ifstream &seed_data, std::string &line);
 
 std::string clientEncrypt(const std::string &value);
 

--- a/src/host/redis.cpp
+++ b/src/host/redis.cpp
@@ -10,8 +10,7 @@ void redisCli::reconnect() {
 }
 
 std::string redisCli::get(const std::string &key) {
-    auto reply = this->redisConn.get(key);
-    return *reply;
+    return this->redisConn.get(key).value_or("");
 }
 
 sw::redis::Pipeline redisCli::pipe() {


### PR DESCRIPTION
This PR accomplishes:
- Addresses multithreading race conditions by streaming the data into a shared queue first then handling data access
- Fixes `redisCli` implementation