### PR TITLE
robust benchmark

### DIFF
--- a/extras/ortoa/benchmark/infrastucture/jobs.py
+++ b/extras/ortoa/benchmark/infrastucture/jobs.py
@@ -8,9 +8,12 @@ import subprocess
 import os
 import yaml
 import json
+import time
 
 from ortoa.benchmark.interface.experiment import AtomicExperiment, ExperimentMetatadata
 
+
+SLEEP_TIME = 1
 
 class ClientFlags(BaseModel):
     initdb: bool = True
@@ -125,10 +128,15 @@ class ClientJob(BaseModel):
 
         with subprocess.Popen(self.host_command) as host_proc:
             self._write_debug_scripts()
+            time.sleep(SLEEP_TIME)
             self._flush_db()
+            time.sleep(SLEEP_TIME)
             self._seed_db()
+            time.sleep(SLEEP_TIME)
             self._perform_operations()
+            time.sleep(SLEEP_TIME)
             self._flush_db()
+            time.sleep(SLEEP_TIME)
             host_proc.terminate()
 
         self._save_results()


### PR DESCRIPTION
After experimentation, I figured out that the benchmark was calling things too quickly and that was causing the failed connection TTransport error thing, maybe the port wasn't terminating its process on time.

This should fix my DB size experiment