### PR TITLE
Enclave Switchless Calls

### DIFF
--- a/src/host/host.cpp
+++ b/src/host/host.cpp
@@ -50,6 +50,14 @@ class RPCHandler : virtual public RPCIf {
             spdlog::debug("Running in simulation mode");
             #endif
 
+            /* It might be more performance advantageous to make the calls context-switchless: 
+               the caller delegates the function call to a worker thread in the other environment, 
+               which does the real job of calling the function and post the result to the caller. 
+               Both the calling thread and the worker thread never leave their respective execution 
+               contexts during the perceived function call.
+
+               To determine the number of worker threads, use the following expression:
+               min(simultaneously active caller threads, cores available to worker threads) */
             oe_enclave_setting_context_switchless_t switchless_setting = {
                 0,  // number of host worker threads, not required since no ocalls
                 1}; // number of enclave worker threads

--- a/src/host/host.cpp
+++ b/src/host/host.cpp
@@ -50,9 +50,18 @@ class RPCHandler : virtual public RPCIf {
             spdlog::debug("Running in simulation mode");
             #endif
 
+            oe_enclave_setting_context_switchless_t switchless_setting = {
+                0,  // number of host worker threads, not required since no ocalls
+                1}; // number of enclave worker threads
+            oe_enclave_setting_t settings[] = {{
+                OE_ENCLAVE_SETTING_CONTEXT_SWITCHLESS,
+                &switchless_setting,
+            }};
+
             oe_result_t result =
                 oe_create_ortoa_enclave(oe_enclave_path, OE_ENCLAVE_TYPE_SGX,
-                                        OE_ENCLAVE_FLAG_SIMULATE, NULL, 0, &enclave);
+                                        OE_ENCLAVE_FLAG_SIMULATE, settings,
+                                        OE_COUNTOF(settings), &enclave);
             if (result != OE_OK) {
                 throw OECreationFailed(oe_enclave_path);
             }

--- a/src/ortoa.edl
+++ b/src/ortoa.edl
@@ -14,7 +14,7 @@ enclave {
                                 [in, count=update_size] const char* update_val,
                                 size_t update_size,
                                 [out, count=in_size] unsigned char* out_val,
-                                size_t* out_size);
+                                size_t* out_size) transition_using_threads;
     };
 };
 


### PR DESCRIPTION
When conducting an ecall from host to enclave, we transition from an untrusted to trusted environment. The transition is costly due to heavy security checks.

As per Open Enclave documentation: 
> it might be more performance advantageous to make the calls context-switchless: the caller delegates the function call to a worker thread in the other environment, which does the real job of calling the function and post the result to the caller. Both the calling thread and the worker thread never leave their respective execution contexts during the perceived function call.

This PR accomplishes:
- Implements switchless calls with 1 worker thread (exact number of worker threads should be determined by the following expression)
> min(number of simultaneously active caller threads, number of cores that are available to worker threads)